### PR TITLE
- fix date time parsing for all `t/sc` ISO-8601 formats;

### DIFF
--- a/app/src/main/java/dgca/verifier/app/android/utils/TimeExt.kt
+++ b/app/src/main/java/dgca/verifier/app/android/utils/TimeExt.kt
@@ -23,10 +23,7 @@
 package dgca.verifier.app.android.utils
 
 import java.text.SimpleDateFormat
-import java.time.Instant
-import java.time.LocalDateTime
-import java.time.ZoneId
-import java.time.ZonedDateTime
+import java.time.*
 import java.time.format.DateTimeFormatter
 import java.util.*
 
@@ -49,9 +46,13 @@ private fun String.toLocalDateTime(): LocalDateTime? =
         null
     }
 
-fun String.toFormattedDateTime(): String? =
-    toZonedDateTime()?.let { "${DATE_TIME_FORMATTER.format(it)} (UTC)" }
-        ?: toLocalDateTime()?.let { "${DATE_TIME_FORMATTER.format(it)} (UTC)" }
+fun String.toFormattedDateTime(): String {
+    if (isEmpty()) {
+        return ""
+    }
+
+    return "${parseDateOfCollectionToUtcTimestamp()} (UTC)"
+}
 
 fun String.parseFromTo(from: String, to: String): String =
     try {
@@ -66,3 +67,23 @@ fun String.parseFromTo(from: String, to: String): String =
 fun Long.toLocalDateTime(): LocalDateTime = LocalDateTime.ofInstant(Instant.ofEpochMilli(this), ZoneId.systemDefault())
 
 fun LocalDateTime.formatWith(pattern: String): String = DateTimeFormatter.ofPattern(pattern).format(this)
+
+fun String?.parseDateOfCollectionToUtcTimestamp(): String {
+    if (isNullOrEmpty()) {
+        return ""
+    }
+
+    return try {
+        val dateTime =
+            DateTimeFormatter.ISO_OFFSET_DATE_TIME.parse(this, OffsetDateTime::from).withOffsetSameInstant(ZoneOffset.UTC)
+        DATE_TIME_FORMATTER.format(dateTime)
+    } catch (ex: Exception) {
+        try {
+            val dateTime = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ssSX").parse(this, OffsetDateTime::from)
+                .withOffsetSameInstant(ZoneOffset.UTC)
+            DATE_TIME_FORMATTER.format(dateTime)
+        } catch (ex: Exception) {
+            ""
+        }
+    }
+}

--- a/app/src/main/java/dgca/verifier/app/android/verification/certs/TestViewHolder.kt
+++ b/app/src/main/java/dgca/verifier/app/android/verification/certs/TestViewHolder.kt
@@ -35,7 +35,7 @@ class TestViewHolder(private val binding: ItemTestBinding) : RecyclerView.ViewHo
     fun bind(data: TestModel) {
         data.disease.value.bindText(binding.diseaseTitle, binding.diseaseValue)
         data.resultType.value.bindText(binding.testResultTitle, binding.testResultValue)
-        (data.dateTimeOfCollection.toFormattedDateTime() ?: "").bindText(
+        data.dateTimeOfCollection.toFormattedDateTime().bindText(
             binding.dateOfCollectionTitle,
             binding.dateOfCollectionValue
         )

--- a/app/src/test/java/dgca/verifier/app/android/TimeExtTest.kt
+++ b/app/src/test/java/dgca/verifier/app/android/TimeExtTest.kt
@@ -27,32 +27,24 @@ import org.junit.Assert
 import org.junit.Test
 
 class TimeExtTest {
-    @Test
-    fun testLocalToFormattedDateTime() {
-        val localDateTimeString = "2021-05-25T09:02:07"
-        val expectedFormattedLocalDateTime = "May 25, 2021, 09:02 (UTC)"
-
-        val actualFormattedLocalDateTime = localDateTimeString.toFormattedDateTime()
-
-        Assert.assertEquals(expectedFormattedLocalDateTime, actualFormattedLocalDateTime)
-    }
 
     @Test
-    fun testZonedToFormattedDateTime() {
-        val zonedDateTimeString = "2021-05-19T08:20:00Z"
-        val expectedFormattedLocalDateTime = "May 19, 2021, 08:20 (UTC)"
+    fun testTimeToUTC_ISO8601_format_SuccessTest() {
+        val format1 = "2021-08-20T05:03:12Z"      // (UTC time)
+        val format2 = "2021-08-20T07:03:12+02"    // (CEST time)
+        val format3 = "2021-08-20T07:03:12+0200"  // (CEST time)
+        val format4 = "2021-08-20T07:03:12+02:00" // (CEST time)
 
-        val actualFormattedLocalDateTime = zonedDateTimeString.toFormattedDateTime()
+        val result1 = format1.toFormattedDateTime()
+        val result2 = format2.toFormattedDateTime()
+        val result3 = format3.toFormattedDateTime()
+        val result4 = format4.toFormattedDateTime()
 
-        Assert.assertEquals(expectedFormattedLocalDateTime, actualFormattedLocalDateTime)
-    }
+        val expectedResult = "Aug 20, 2021, 05:03 (UTC)"
 
-    @Test
-    fun testCustomDateTime() {
-        val zonedDateTimeString = "1 1 2021"
-
-        val actualFormattedLocalDateTime = zonedDateTimeString.toFormattedDateTime()
-
-        Assert.assertNull(actualFormattedLocalDateTime)
+        Assert.assertEquals(expectedResult, result1)
+        Assert.assertEquals(expectedResult, result2)
+        Assert.assertEquals(expectedResult, result3)
+        Assert.assertEquals(expectedResult, result4)
     }
 }


### PR DESCRIPTION
closes #187 