### PR TITLE
Fixed the NFC COVID certificate scanner

### DIFF
--- a/app/src/main/java/dgca/verifier/app/android/MainActivity.kt
+++ b/app/src/main/java/dgca/verifier/app/android/MainActivity.kt
@@ -113,25 +113,24 @@ class MainActivity : AppCompatActivity() {
             return
         }
 
-        val builder = StringBuilder()
-        val records = NdefParser.parse(messages[0])
-        val size = records.size
+        val itr = messages.listIterator()
 
-        for (i in 0 until size) {
-            val record = records[i]
-            val str = record.str()
-            builder.append(str)
-        }
+        while (itr.hasNext()) {
+            val records = NdefParser.parse(itr.next())
 
-        val qrCodeText = builder.toString()
-        if (qrCodeText.isNotEmpty()) {
-            navHostFragment.childFragmentManager.primaryNavigationFragment?.let { fragment ->
-                if (fragment is CodeReaderFragment && fragment.isVisible) {
-                    fragment.onNdefMessageReceived(qrCodeText)
+            for (i in 0 until records.size) {
+                if (records[i] != null) {
+                    val record = records[i].str()
+
+                    if (record.length >= 5 && record.substring(0, 4) == "HC1:") {
+                       navHostFragment.childFragmentManager.primaryNavigationFragment?.let { fragment ->
+                            if (fragment is CodeReaderFragment && fragment.isVisible) {
+                                fragment.onNdefMessageReceived(record)
+                            }
+                        }
+                    }
                 }
             }
-        } else {
-            Timber.d("Received empty NDEFMessage")
         }
     }
 }

--- a/app/src/main/java/dgca/verifier/app/android/nfc/NdefParser.kt
+++ b/app/src/main/java/dgca/verifier/app/android/nfc/NdefParser.kt
@@ -65,7 +65,9 @@ fun NdefRecord.parse(): ParsedNdefRecord? {
                 Charsets.UTF_16
             }
 
-            val text = String(recordPayload, textEncoding)
+            val langCodeLen = (recordPayload[0] and 63.toByte()).toInt()
+            val text = String(recordPayload, textEncoding).substring(1 + langCodeLen)
+
             return TextRecord(text)
         } catch (e: UnsupportedEncodingException) {
             Timber.w("We got a malformed tag.")

--- a/app/src/main/java/dgca/verifier/app/android/reader/CodeReaderFragment.kt
+++ b/app/src/main/java/dgca/verifier/app/android/reader/CodeReaderFragment.kt
@@ -267,11 +267,15 @@ class CodeReaderFragment : BindingFragment<FragmentCodeReaderBinding>(), NavCont
     }
 
     fun onNdefMessageReceived(qrCodeText: String) {
-        val action =
-            CodeReaderFragmentDirections.actionCodeReaderFragmentToVerificationDialogFragment(
+        try {
+            val action =
+                CodeReaderFragmentDirections.actionCodeReaderFragmentToVerificationDialogFragment(
                 qrCodeText,
                 binding.countrySelector.selectedItem?.toString() ?: ""
-            )
-        findNavController().navigate(action)
+                )
+            findNavController().navigate(action)
+        } catch (ex: Exception) {
+            Timber.d("action_codeReaderFragment_to_verificationDialogFragment cannot be found from the current destination Destination.")
+        }
     }
 }

--- a/app/src/main/java/dgca/verifier/app/android/reader/CodeReaderFragment.kt
+++ b/app/src/main/java/dgca/verifier/app/android/reader/CodeReaderFragment.kt
@@ -267,21 +267,11 @@ class CodeReaderFragment : BindingFragment<FragmentCodeReaderBinding>(), NavCont
     }
 
     fun onNdefMessageReceived(qrCodeText: String) {
-        val position = binding.countrySelector.selectedItemPosition
-        if (position == -1 || refinedCountries.isEmpty()) {
-            return
-        }
-
-        try {
-            val countryCode = refinedCountries[position].toLowerCase(Locale.ROOT)
-            val action =
-                CodeReaderFragmentDirections.actionCodeReaderFragmentToVerificationDialogFragment(
-                    qrCodeText,
-                    countryCode
-                )
-            findNavController().navigate(action)
-        } catch (ex: Exception) {
-            Timber.d("Cannot get iso country code for position.")
-        }
+        val action =
+            CodeReaderFragmentDirections.actionCodeReaderFragmentToVerificationDialogFragment(
+                qrCodeText,
+                binding.countrySelector.selectedItem?.toString() ?: ""
+            )
+        findNavController().navigate(action)
     }
 }


### PR DESCRIPTION
This is a fix to let the DGCA Verifier app correctly interpret the string of a COVID certificate QR code stored on an NFC tag as a plain text NDEF record (urn:nfc:wkt:T). The app didn't work because it failed to strip out the language code from the NDEF record payload in NdefParser.kt. Also, it choked on a piece of code that couldn't determine the ISO country code in CodeReaderFragment.kt.